### PR TITLE
Fix Windows build and remove map of TaskLists

### DIFF
--- a/source/renderer.hpp
+++ b/source/renderer.hpp
@@ -39,7 +39,7 @@ struct Renderer
         daxa::PipelineCompiler pipeline_compiler;
 
         ApplicationImages images;
-        std::unordered_map<std::string, ApplicationTask> tasks;
+        ApplicationTask clear_present_task;
 
         void record_tasks();
         void create_resources();

--- a/source/window.hpp
+++ b/source/window.hpp
@@ -65,7 +65,7 @@ struct AppWindow
         auto get_native_handle() -> daxa::NativeWindowHandle 
         {
 #if defined(_WIN32)
-            return glfwGetWin32Window(glfw_window_ptr);
+            return glfwGetWin32Window(window);
 #elif defined(__linux__)
             return reinterpret_cast<daxa::NativeWindowHandle>(glfwGetX11Window(window));
 #endif


### PR DESCRIPTION
This PR both fixes Windows build errors, as well as the bugs you were having where the app croaks when closing. (As discussed in Discord) This was because of some ownership issues with TaskList that come about when you're moving it around in the map. As I was unable to see the purpose of the map of task lists (plus I believe you're only supposed to use one) I made the `Renderer` class just declare a `clear_present_task`, which is now constructed in the initializer list of `Renderer`